### PR TITLE
Updated iOS EKO connect SDK to 1.4.0 and deployment target to iOS 13.0.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
             <feature name="EkoDuoPlugin">
                 <param name="ios-package" value="EkoDuoPlugin" />
             </feature>
-            <preference name="deployment-target" value="12.0" />
+            <preference name="deployment-target" value="13.0" />
         </config-file>
         <source-file src="src/ios/EkoDuoPlugin.swift" />
         <podspec>
@@ -31,13 +31,10 @@
             <pods use-frameworks="true">
                     <pod name="SocketRocket" />
                     <pod name="SwiftLint" />
-                    <pod name="EkoConnect" spec="~> 1.2.0" />
+                    <pod name="EkoConnectSDK" spec="~> 1.4.0" />
                     <pod name="TensorFlowLiteSwift" spec="~> 2.9.1" />
                     <pod name="CocoaLumberjack/Swift" spec="~> 3.6.0" />
             </pods>
         </podspec>
     </platform>
 </plugin>
-
-
-


### PR DESCRIPTION
Below are the changes : 
1. Changed version of Eko connect to 1.4.0.
2. Changed minimum deployment target of iOS to iOS 13.0